### PR TITLE
Update package.json and update to ES modules; pass first test with empty string

### DIFF
--- a/lib/mumble.js
+++ b/lib/mumble.js
@@ -2,4 +2,4 @@ const mumble = (string) => {
   return nil;
 };
 
-export { mumble };
+export {mumble};

--- a/lib/mumble.js
+++ b/lib/mumble.js
@@ -1,5 +1,5 @@
 const mumble = (string) => {
-  return nil;
+  return '';
 };
 
-export {mumble};
+export { mumble };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "kata",
   "version": "0.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "index.j",
   "directories": {
     "test": "test"
   },
@@ -15,5 +15,4 @@
   "dependencies": {
     "mocha": "~1.12.0"
   }
-  
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "kata",
   "version": "0.0.0",
   "description": "",
@@ -14,4 +15,5 @@
   "dependencies": {
     "mocha": "~1.12.0"
   }
+  
 }

--- a/test/mumble.js
+++ b/test/mumble.js
@@ -1,4 +1,4 @@
-import { mumble } from "../lib/mumble";
+import { mumble } from "../lib/mumble.js";
 // require("../lib/mumble.js");
 var assert = require("assert");
 

--- a/test/mumble.js
+++ b/test/mumble.js
@@ -1,10 +1,10 @@
 import { mumble } from "../lib/mumble.js";
-// require("../lib/mumble.js");
-var assert = require("assert");
+
+import assert from 'assert';
 
 describe("Mumble", function () {
   it("handles empty strings", function () {
-    input_string = "";
+    const input_string = "";
     assert.strictEqual("", mumble(input_string));
   });
 });


### PR DESCRIPTION
Dropped CommonJS syntax in favour of ESM. 

There is currently an error with the return value.